### PR TITLE
feat: allow to observe logs at runtime

### DIFF
--- a/examples/mars-rover/tests.ts
+++ b/examples/mars-rover/tests.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk'
 import path from 'path'
 import { runFolder } from '../../runner/runFolder.js'
 import { RoverContext, steps } from './steps.js'
@@ -5,6 +6,14 @@ import { RoverContext, steps } from './steps.js'
 const runner = await runFolder<RoverContext>({
 	folder: path.join(process.cwd(), 'examples', 'mars-rover'),
 	name: 'Mars Rover',
+	logObserver: {
+		onProgress: ({ ts }, ...progress) =>
+			console.error(
+				chalk.gray(`»`),
+				chalk.cyan(`@${ts}`),
+				...progress.map((s) => chalk.yellow(s)),
+			),
+	},
 })
 
 runner.addStepRunners(...steps)

--- a/runner/logger.ts
+++ b/runner/logger.ts
@@ -1,8 +1,26 @@
-export type Logger = {
+import { Feature, Scenario, Step } from '../parser/grammar.js'
+
+export type Logger<Context extends Feature | Scenario | Step> = {
+	/**
+	 * Logs a debug message
+	 */
 	debug: (...args: string[]) => void
+	/**
+	 * Logs a info message
+	 */
 	info: (...args: string[]) => void
+	/**
+	 * Logs a error message
+	 */
 	error: (error: ErrorInfo) => void
+	/**
+	 * Logs a progress message
+	 */
 	progress: (...args: string[]) => void
+	/**
+	 * Returns the context of the logger.
+	 */
+	context: Context
 }
 
 type ErrorInfo = {
@@ -26,37 +44,87 @@ export type LogEntry = {
 	ts: number
 }
 
-export const logger = ({
+type LogObserverInfo = {
+	context: Feature | Scenario | Step
+	level: LogLevel
+	/**
+	 * Time in ms from beginning of the feature run when the log message was created
+	 */
+	ts: number
+}
+
+export type LogObserver = {
+	/**
+	 * Register a listener that receives debug logs
+	 */
+	onDebug?: (info: LogObserverInfo, ...args: string[]) => unknown
+	/**
+	 * Register a listener that receives info logs
+	 */
+	onInfo?: (info: LogObserverInfo, ...args: string[]) => unknown
+	/**
+	 * Register a listener that receives error logs
+	 */
+	onError?: (info: LogObserverInfo, error: ErrorInfo) => unknown
+	/**
+	 * Register a listener that receives progress logs
+	 */
+	onProgress?: (info: LogObserverInfo, ...args: string[]) => unknown
+}
+
+export const logger = <Context extends Feature | Scenario | Step>({
+	context,
 	getRelativeTs,
+	onDebug,
+	onError,
+	onInfo,
+	onProgress,
 }: {
+	/**
+	 * The context the logs of this logger are coming from
+	 */
+	context: Context
+	/**
+	 * Returns the number of milliseconds that have elapse since the "start" of the test run.
+	 */
 	getRelativeTs: () => number
-}): Logger & { getLogs: () => LogEntry[] } => {
+} & LogObserver): Logger<Context> & { getLogs: () => LogEntry[] } => {
 	const logs: LogEntry[] = []
+	const ts = getRelativeTs()
 	return {
-		debug: (...message) =>
+		debug: (...message) => {
 			logs.push({
 				message,
 				level: LogLevel.DEBUG,
-				ts: getRelativeTs(),
-			}),
-		progress: (...message) =>
+				ts,
+			})
+			onDebug?.({ context, ts, level: LogLevel.DEBUG }, ...message)
+		},
+		progress: (...message) => {
 			logs.push({
 				message,
 				level: LogLevel.PROGRESS,
-				ts: getRelativeTs(),
-			}),
-		info: (...message) =>
+				ts,
+			})
+			onProgress?.({ context, ts, level: LogLevel.PROGRESS }, ...message)
+		},
+		info: (...message) => {
 			logs.push({
 				message,
 				level: LogLevel.INFO,
-				ts: getRelativeTs(),
-			}),
-		error: (error) =>
+				ts,
+			})
+			onInfo?.({ context, ts, level: LogLevel.INFO }, ...message)
+		},
+		error: (error) => {
 			logs.push({
 				message: [error.message],
 				level: LogLevel.ERROR,
-				ts: getRelativeTs(),
-			}),
+				ts,
+			})
+			onError?.({ context, ts, level: LogLevel.ERROR }, error)
+		},
 		getLogs: () => logs,
+		context,
 	}
 }

--- a/runner/runFolder.ts
+++ b/runner/runFolder.ts
@@ -1,9 +1,11 @@
+import { LogObserver } from './logger.js'
 import { parseFeaturesInFolder } from './parseFeaturesInFolder.js'
 import { Runner, runSuite } from './runSuite.js'
 
 export const runFolder = async <Context extends Record<string, any>>({
 	folder,
 	name,
+	logObserver,
 }: {
 	/**
 	 * The name for the test suite
@@ -13,5 +15,9 @@ export const runFolder = async <Context extends Record<string, any>>({
 	 * A path to a folder to load the features from
 	 */
 	folder: string
+	/**
+	 * Observe logs while they are being emitted
+	 */
+	logObserver?: LogObserver
 }): Promise<Runner<Context>> =>
-	runSuite<Context>(await parseFeaturesInFolder(folder), name)
+	runSuite<Context>(await parseFeaturesInFolder(folder), name, logObserver)

--- a/runner/runScenario.spec.ts
+++ b/runner/runScenario.spec.ts
@@ -33,7 +33,7 @@ describe('runScenario()', () => {
 			scenario: feature.scenarios[0] as Scenario,
 			context: {},
 			getRelativeTs: getRelativeTs,
-			featureLogger: logger({ getRelativeTs }),
+			featureLogger: logger({ getRelativeTs, context: feature }),
 		}
 	})
 
@@ -138,7 +138,7 @@ describe('runScenario()', () => {
 			scenario: feature.scenarios[0] as Scenario,
 			context: {},
 			getRelativeTs: getRelativeTs,
-			featureLogger: logger({ getRelativeTs }),
+			featureLogger: logger({ getRelativeTs, context: feature }),
 		})
 
 		assert.equal(scenarioResult.ok, true)

--- a/runner/runScenario.ts
+++ b/runner/runScenario.ts
@@ -1,5 +1,5 @@
 import { Feature, Scenario, Step } from '../parser/grammar.js'
-import { LogEntry, logger, Logger } from './logger.js'
+import { LogEntry, logger, Logger, LogObserver } from './logger.js'
 import { runStep, StepResult, StepRunner } from './runStep.js'
 
 export type ScenarioResult = {
@@ -17,16 +17,22 @@ export const runScenario = async <Context extends Record<string, any>>({
 	context,
 	getRelativeTs,
 	featureLogger,
+	logObserver,
 }: {
 	stepRunners: StepRunner<Context>[]
 	feature: Feature
 	scenario: Scenario
 	context: Context
-	featureLogger: Logger
+	featureLogger: Logger<Feature>
 	getRelativeTs: () => number
+	logObserver?: LogObserver
 }): Promise<Omit<ScenarioResult, 'skipped'>> => {
 	const startTs = Date.now()
-	const scenarioLogger = logger({ getRelativeTs })
+	const scenarioLogger = logger({
+		getRelativeTs,
+		context: scenario,
+		...logObserver,
+	})
 	const stepResults: [Step, StepResult][] = []
 
 	let aborted = false
@@ -58,6 +64,7 @@ export const runScenario = async <Context extends Record<string, any>>({
 			getRelativeTs,
 			featureLogger,
 			scenarioLogger,
+			logObserver,
 		})
 		stepResults.push([
 			step,

--- a/runner/runStep.spec.ts
+++ b/runner/runStep.spec.ts
@@ -26,16 +26,20 @@ describe('runStep()', () => {
 	beforeEach(async () => {
 		const feature = await f()
 		const getRelativeTs = () => 42
+		const scenario = feature.scenarios[0] as Scenario
 		runStepArgs = {
 			stepRunners: [],
 			feature,
-			scenario: feature.scenarios[0] as Scenario,
+			scenario,
 			step: feature.scenarios[0].steps[0],
 			context: {},
 			previousResults: [],
 			getRelativeTs: getRelativeTs,
-			featureLogger: logger({ getRelativeTs }),
-			scenarioLogger: logger({ getRelativeTs }),
+			featureLogger: logger({ getRelativeTs, context: feature }),
+			scenarioLogger: logger({
+				getRelativeTs,
+				context: scenario,
+			}),
 		}
 	})
 

--- a/runner/runSuite.ts
+++ b/runner/runSuite.ts
@@ -1,4 +1,5 @@
 import { ParsedPath } from 'path'
+import { LogObserver } from './logger.js'
 import { orderFeatures } from './orderFeatures.js'
 import { FeatureFile } from './parseFeaturesInFolder.js'
 import { FeatureResult, runFeature } from './runFeature.js'
@@ -24,6 +25,7 @@ export type Runner<Context extends Record<string, any>> = {
 export const runSuite = <Context extends Record<string, any>>(
 	featureFiles: FeatureFile[],
 	name: string,
+	logObserver?: LogObserver,
 ): Runner<Context> => {
 	const stepRunners: StepRunner<Context>[] = []
 
@@ -70,6 +72,7 @@ export const runSuite = <Context extends Record<string, any>>(
 								feature,
 								// Create a new context per feature
 								context: JSON.parse(JSON.stringify(context ?? {})),
+								logObserver,
 						  })
 				featureResults.push([file, result])
 				featureNameResultMap[feature.title ?? file.name] = result.ok


### PR DESCRIPTION
This adds a log observer which receives logs created
from Features, Scenarios and Steps immediately
